### PR TITLE
use total field from CDM manifest for harvest size; don't index colle…

### DIFF
--- a/app/models/iiif_builder.rb
+++ b/app/models/iiif_builder.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# harvest Images from IIIF Manifest and turn them into a Spotlight::Resource
+# Note: IIIF API : http://iiif.io/api/presentation/2.0
+class IiifBuilder < Spotlight::Resources::IiifBuilder
+
+  alias_method :documents_to_index_orig, :documents_to_index
+  attr_accessor :total
+
+  def documents_to_index
+    @total ||= 1
+    return to_enum(:documents_to_index_orig) { @total } unless block_given?
+    documents_to_index_orig.call(&block)
+  end
+end

--- a/app/models/iiif_harvester.rb
+++ b/app/models/iiif_harvester.rb
@@ -4,7 +4,15 @@
 # Note: IIIF API : http://iiif.io/api/presentation/2.0
 class IiifHarvester < Spotlight::Resources::IiifHarvester
 
+  self.document_builder_class = ::IiifBuilder
+
   def iiif_manifests
     @iiif_manifests ||= ::IiifService.parse(url)
+  end
+
+  def document_builder
+    builder = super
+    builder.total = ::IiifService.get_total(url)
+    builder
   end
 end

--- a/app/models/iiif_service.rb
+++ b/app/models/iiif_service.rb
@@ -6,13 +6,9 @@ class IiifService < Spotlight::Resources::IiifService
     @manifests ||= if manifest?
                      [create_iiif_manifest(object)]
                    elsif object.respond_to? :manifests
-                     result = object.manifests.map { |manifest|
+                     object.manifests.map { |manifest|
                        create_iiif_manifest(manifest)
                      }
-                     if collection?
-                       result << create_iiif_manifest(object)
-                     end
-                     result
                    else
                      build_collection_manifest.to_a
                    end
@@ -37,5 +33,13 @@ class IiifService < Spotlight::Resources::IiifService
       next_page_url = object.to_ordered_hash.dig(pointer, "@id")
       yield self.class.new(next_page_url) if next_page_url
     end
+  end
+
+  def total
+    object['total']
+  end
+
+  def self.get_total(url)
+    new(url).total
   end
 end

--- a/spec/models/iiif_harvester_spec.rb
+++ b/spec/models/iiif_harvester_spec.rb
@@ -12,9 +12,11 @@ describe ::IiifHarvester do
     let(:url) { 'https://digital.library.temple.edu/iiif/info/p16002coll4/manifest.json' }
 
     it 'returns an Enumerator of all the solr documents' do
-      VCR.use_cassette("p16002coll4_manifests") do
-        expect(subject.documents_to_index).to be_a(Enumerator)
-        expect(subject.documents_to_index.count).to eq 143
+      VCR.use_cassette("p16002coll4_manifests", :allow_playback_repeats => true) do
+        enum = subject.documents_to_index
+        expect(enum).to be_a(Enumerator)
+        expect(enum.count).to eq 142
+        expect(enum.size).to eq 142
       end
     end
   end
@@ -25,9 +27,9 @@ describe ::IiifHarvester do
     let(:url) { 'https://digital.library.temple.edu/iiif/info/p16002coll2/manifest.json' }
 
     it 'returns an Enumerator of all the solr documents' do
-      VCR.use_cassette("p16002coll2_manifests") do
+      VCR.use_cassette("p16002coll2_manifests", :allow_playback_repeats => true) do
         expect(subject.documents_to_index).to be_a(Enumerator)
-        expect(subject.documents_to_index.count).to eq 2318
+        expect(subject.documents_to_index.count).to eq 2314
       end
     end
   end


### PR DESCRIPTION
…ction manifests

Use the "total" field in the CDM manifest to get the size of the set of solr documents.

Prevent indexing of manifests that wrap items.