### PR TITLE
avoid making redundant calls to cdm manifest urls

### DIFF
--- a/app/models/iiif_builder.rb
+++ b/app/models/iiif_builder.rb
@@ -5,11 +5,11 @@
 class IiifBuilder < Spotlight::Resources::IiifBuilder
 
   alias_method :documents_to_index_orig, :documents_to_index
-  attr_accessor :total
+
+  delegate :total, to: :resource
 
   def documents_to_index
-    @total ||= 1
-    return to_enum(:documents_to_index_orig) { @total } unless block_given?
+    return to_enum(:documents_to_index_orig) { total } unless block_given?
     documents_to_index_orig.call(&block)
   end
 end

--- a/app/models/iiif_harvester.rb
+++ b/app/models/iiif_harvester.rb
@@ -6,13 +6,19 @@ class IiifHarvester < Spotlight::Resources::IiifHarvester
 
   self.document_builder_class = ::IiifBuilder
 
-  def iiif_manifests
-    @iiif_manifests ||= ::IiifService.parse(url)
+  # We don't use the IiifService.parse method because
+  # we want to get the total for the set before we start
+  # retrieving all the pages
+
+  def iiif_service
+    @iiif_service ||= ::IiifService.new(url)
   end
 
-  def document_builder
-    builder = super
-    builder.total = ::IiifService.get_total(url)
-    builder
+  def iiif_manifests
+    @iiif_manifests ||= ::IiifService.recursive_manifests(iiif_service)
+  end
+
+  def total
+    iiif_service.total
   end
 end

--- a/app/models/iiif_service.rb
+++ b/app/models/iiif_service.rb
@@ -27,10 +27,6 @@ class IiifService < Spotlight::Resources::IiifService
     object['total']
   end
 
-  def self.get_total(url)
-    new(url).total
-  end
-
   def build_collection_manifest
     return to_enum(:build_collection_manifest) unless block_given?
 

--- a/spec/models/iiif_harvester_spec.rb
+++ b/spec/models/iiif_harvester_spec.rb
@@ -12,7 +12,7 @@ describe ::IiifHarvester do
     let(:url) { 'https://digital.library.temple.edu/iiif/info/p16002coll4/manifest.json' }
 
     it 'returns an Enumerator of all the solr documents' do
-      VCR.use_cassette("p16002coll4_manifests", :allow_playback_repeats => true) do
+      VCR.use_cassette("p16002coll4_manifests") do
         enum = subject.documents_to_index
         expect(enum).to be_a(Enumerator)
         expect(enum.count).to eq 142
@@ -21,7 +21,7 @@ describe ::IiifHarvester do
     end
 
     it 'captures CDM metadata in the solr document' do
-      VCR.use_cassette("p16002coll4_manifests", :allow_playback_repeats => true) do
+      VCR.use_cassette("p16002coll4_manifests") do
         enum = subject.documents_to_index
         first_doc = enum.to_a[0]
         expect(first_doc['full_title_tesim']).to eq '[Letter of 1866 April 30]'
@@ -36,7 +36,7 @@ describe ::IiifHarvester do
     let(:url) { 'https://digital.library.temple.edu/iiif/info/p16002coll2/manifest.json' }
 
     it 'returns an Enumerator of all the solr documents' do
-      VCR.use_cassette("p16002coll2_manifests", :allow_playback_repeats => true) do
+      VCR.use_cassette("p16002coll2_manifests") do
         expect(subject.documents_to_index).to be_a(Enumerator)
         expect(subject.documents_to_index.count).to eq 2314
       end


### PR DESCRIPTION
A little refactoring so we don't have to instantiate IiifService twice and fetch XML docs twice.